### PR TITLE
Added image and text component to exhibit

### DIFF
--- a/client/assets/components/exhibitPanel.html
+++ b/client/assets/components/exhibitPanel.html
@@ -14,6 +14,12 @@
     </div>
 
 
+    <div class="" ng-if="context.pageElements.contentType=='imageAndText'">
+
+        <div class="grid-content" style="padding-top: 8px;">
+            <exb-text-and-image context="context"></div>
+    </div>
+
     <div class="grid-content" ng-if="context.pageElements.contentType=='pagesArray'">
         <div  style="padding-top: 8px;">
             <exb-page-carousel></exb-page-carousel>

--- a/client/assets/components�textAndImage.html
+++ b/client/assets/components�textAndImage.html
@@ -1,0 +1,18 @@
+<div class="block-block">
+
+    <!-- zf-interchange throwing error in console, perhaps because images are indentical -->
+    <!-- <zf-interchange> -->
+    <!-- <img media="small" src="/assets/images/{{context.pageElements.imageFileName}}.jpg">
+     <img media="medium" src="/assets/images/{{context.pageElements.imageFileName}}.jpg">   -->
+
+    <div class="grid-content">
+        <div class="card" style="background: transparent !important; border: none; color: #B8B097;box-shadow: none;">
+            <img media="large" src="assets/images/{{context.pageElements.imageFileName}}.jpg" align="{{context.pageElements.imageAlign}}" style="padding: 15px; width: 45%;" >
+            <!--   </zf-interchange>-->
+            <div style="width:85%;">
+            <ng-include src="context.pageElements.html" style="padding: 15px;"></ng-include>
+            </div>
+
+        </div>
+    </div>
+</div>

--- a/client/assets/js/directives.js
+++ b/client/assets/js/directives.js
@@ -45,7 +45,7 @@ exhibitDirectives.directive('exbTextAndImage', function() {
         scope: false,
         restrict: 'EA',
         replace: true,
-        templateUrl: 'assets/components/pageTurner.html'
+        templateUrl: 'assets/components/textAndImage.html'
     }
 });
 

--- a/client/assets/js/services.js
+++ b/client/assets/js/services.js
@@ -9,7 +9,7 @@ exhibitServices.factory('exhibitLayoutFactory', function($http) {
 
     var _imageFileName;
 
-    var _currentPage;
+    var _currentHtmlPage;
 
     var _imageTitle;
 
@@ -40,6 +40,8 @@ exhibitServices.factory('exhibitLayoutFactory', function($http) {
     var _creator;
 
     var _citationType;
+
+    var _imageAlign;
 
     var service = {};
 
@@ -81,13 +83,14 @@ exhibitServices.factory('exhibitLayoutFactory', function($http) {
             citationType: '',
             html: '',
             imageArray: '',
+            imageAlign: '',
             contentType: ''
         }
 
     };
 
-    // Retrieves the exhibit json file and sets layout object
-    // JSON array. Returns a reference to the controller.
+    // Retrieves the exhibit json file and sets layout JSON object.
+    // Returns a reference to the layout object to the controller.
     service.init = function(callback) {
 
         $http.get('assets/layout/exhibit.json').
@@ -129,23 +132,30 @@ exhibitServices.factory('exhibitLayoutFactory', function($http) {
     service.setCurrentPage = function(position) {
 
         _imageFileName = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageFileName;
-        _currentPage =  layout.components[_selectedItemPrimary].section.secondaryNav[position].section.html;
+        _currentHtmlPage =  layout.components[_selectedItemPrimary].section.secondaryNav[position].section.html;
         _imageTitle = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.title;
         _description =  layout.components[_selectedItemPrimary].section.secondaryNav[position].section.description;
         _contentType =  layout.components[_selectedItemPrimary].section.secondaryNav[position].section.type;
         _date = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.date;
         _creator = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.creator;
         _citationType =  layout.components[_selectedItemPrimary].section.secondaryNav[position].section.citationType;
+        _imageAlign = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageAlign;
         if (layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageArray != null) {
             _imageArray = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageArray;
         } else {
             _imageArray = [];
         }
+        if  (layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageAlign !== undefined) {
+            _imageAlign = layout.components[_selectedItemPrimary].section.secondaryNav[position].section.imageAlign;
+        }  else {
+            _imageAlign = "left";
+        }
 
         // page elements
-        service.context.pageElements.html = _currentPage;
+        service.context.pageElements.html = _currentHtmlPage;
         service.context.pageElements.imageArray = _imageArray;
         service.context.pageElements.imageFileName = _imageFileName;
+        service.context.pageElements.imageAlign = _imageAlign;
         service.context.pageElements.contentType = _contentType;
         service.context.pageElements.citationType = _citationType;
         service.context.pageElements.title = _imageTitle;
@@ -161,7 +171,7 @@ exhibitServices.factory('exhibitLayoutFactory', function($http) {
 
         _selectedItemPrimary = position;
         _contentTypePrimary = layout.components[position].section.type;
-        if (_contentType == 'text') {
+        if (_contentType === 'text') {
             _contentCategoryPrimary = 'textinfo';
         }  else {
             _contentCategoryPrimary = 'imageinfo';

--- a/client/assets/layout/exhibit.json
+++ b/client/assets/layout/exhibit.json
@@ -55,6 +55,30 @@
             "description": "again all this from the exhibit.json file - no html file",
             "imageFileName": "ExampleImage2"
           }
+        },
+        {
+          "section": {
+            "type": "imageAndText",
+            "title": "LeftNav1Sub4 (text+image)",
+            "creator": "creator name",
+            "date": "c. date",
+            "citationType": "artwork",
+            "imageAlign": "right",
+            "imageFileName": "ExampleImage2",
+            "html": "assets/html/sections/LeftNav4Sub1.html"
+          }
+        },
+        {
+          "section": {
+            "type": "imageAndText",
+            "title": "LeftNav1Sub5 (text+image)",
+            "creator": "creator name",
+            "date": "c. date",
+            "citationType": "artwork",
+            "imageAlign": "left",
+            "imageFileName": "ExampleImage1",
+            "html": "assets/html/sections/LeftNav4Sub1.html"
+          }
         }
       ]
     }


### PR DESCRIPTION
Pages containing an image with wrapped text can now be created.  Here's a sample of the new section in exhibit.json:

`{
          "section": {
            "type": "imageAndText",
            "title": "LeftNav1Sub5 (text+image)",
            "creator": "creator name",
            "date": "c. date",
            "citationType": "artwork",
            "imageAlign": "left",
            "imageFileName": "ExampleImage1",
            "html": "assets/html/sections/LeftNav4Sub1.html"
          }
        }`
